### PR TITLE
1.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ To assess Web Application implementation correctness and expedite issues discove
   - Warn if it exceeds 4/5 (13.33ms) of 60 FPS hardcoded frame-rate (16.66ms).
 
 - Count calls per second (CPS) when applicable.
-  - If requested recursively - it reflects animation FPS.
 
 - Detect `eval` function usage in runtime, as well as `setTimeout` and `setInterval` when called with a `string` callback instead of a `function`.
   - By default - `off`, cause the fact of wrapping it, excludes the access to local scope variables from the `eval` script, and as a result, may break the application if it does depend on it.

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.0",
+  "version": "1.4.1",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxQCaHgX3DkPnGmHr+rhWyPvYemxMhBbvulmj4RvEpAnGVprdPCUiHSY0jOcDn3vnU6zm8mR1mT3sdlYoUGikBIT19/Jf1iGlc2dySt2bmDQXlTrqllT/XB8HW/wruFej9waMw9yqtW1wOJtElxWnT11pzXkKeflH1Sh+//Jnplr577vOmWh9TU8JLJHS9WklPHJyXCCMGrg/0Sxqte5qWryE2yIm9375KGkKN4ZKjSIxaCg0qodhf5Ug9s2QD7/s5xt548gbEUm9LqQHkNoIH3KXuYOnLksJFxi7FDwhg+oXalsONr5eEvPjkwxYpMKJXfRSg8sB8N6cXLUfgLAKUwIDAQAB",
   "name": "API Monitor",
   "manifest_version": 3,

--- a/src/api-monitor-cs-main.ts
+++ b/src/api-monitor-cs-main.ts
@@ -17,8 +17,8 @@ let currentMetrics: TTelemetry | null;
 const eachSecond = new Timer(
   { type: ETimer.TIMEOUT, timeout: 1e3 },
   function apiMonitorEachSecond() {
-    onEachSecond();
     eachSecond.start();
+    onEachSecond();
   },
 );
 const tick = new Timer({

--- a/src/api/time.ts
+++ b/src/api/time.ts
@@ -281,10 +281,10 @@ export class Fps {
 
   constructor(callback?: (value: number) => void) {
     this.#eachSecond = new Timer({ type: ETimer.TIMEOUT, timeout: 1e3 }, () => {
+      this.#eachSecond.start();
       this.value = this.#ticks;
       this.#ticks = 0;
       callback?.(this.value);
-      this.#eachSecond.start();
     });
   }
 

--- a/src/view/ConnectionAlert.svelte
+++ b/src/view/ConnectionAlert.svelte
@@ -19,11 +19,11 @@
   const extensionUpdateSensor = new Timer(
     { type: ETimer.TIMEOUT, timeout: UPDATE_SENSOR_INTERVAL },
     () => {
+      extensionUpdateSensor.start();
       whenUpdateDetected(() => {
         devtoolsReloadAlertEl?.show();
         extensionUpdateSensor.stop();
       });
-      extensionUpdateSensor.start();
     },
   );
 

--- a/src/view/panels/shared/CellSelfTimeStats.svelte
+++ b/src/view/panels/shared/CellSelfTimeStats.svelte
@@ -19,6 +19,8 @@
   const eachSecond = new Timer(
     { type: ETimer.TIMEOUT, timeout: 1e3 },
     () => {
+      eachSecond.start();
+
       if (!mean.samples) {
         return;
       }
@@ -28,7 +30,6 @@
       vs.max = mean.max;
 
       mean.reset();
-      eachSecond.start();
     },
   );
 


### PR DESCRIPTION
- Fix self-time stats: 1sec leap doesn't continue if no new samples


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted timer callback order in several components to improve timing accuracy and reliability.
* **Documentation**
  * Updated README to remove an outdated note regarding animation FPS.
* **Chores**
  * Incremented version number to 1.4.1 in the manifest file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->